### PR TITLE
fix: Extra slashes and output message

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -14,8 +14,9 @@ await new Command()
     if (out === "-") {
       console.log(xml);
     } else {
-      await Deno.writeTextFile(out ?? join(root, "sitemap.xml"), xml);
-      console.log("Sitemap written to", out);
+      out ??= join(root, "sitemap.xml");
+      await Deno.writeTextFile(out, xml);
+      console.log(`Sitemap written to %c${out}`, "color: blue");
     }
   })
   .parse(Deno.args);

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export { join } from "https://deno.land/std@0.177.0/path/mod.ts";
+export { join, normalize, sep } from "https://deno.land/std@0.177.0/path/mod.ts";

--- a/gen.ts
+++ b/gen.ts
@@ -1,4 +1,4 @@
-import { join } from "./deps.ts";
+import { join, normalize, sep } from "./deps.ts";
 
 /**
  * An object representing an entry in a sitemap
@@ -49,8 +49,10 @@ export async function generateSitemap(
         await addDirectory(path);
       } else if (entry.isFile) {
         const { mtime } = await Deno.stat(path);
+        const relPath = distDirectory === "." ? path : path.substring(distDirectory.length);
+        const pathname = normalize(`/${relPath}`).split(sep).join("/");
         sitemap.push({
-          loc: `${basename}/${path.substring(distDirectory.length)}`,
+          loc: basename + pathname,
           lastmod: (mtime ?? new Date()).toISOString(),
         });
       } else {


### PR DESCRIPTION
- Fixed output message saying `Sitemap written to undefined` (screenshot: https://t.me/grammyjs/114932) when -out is not provided. And added a little color to the filepath part of the message to make it look fancy.
- Fixed double slashes in the `loc` fields of the output if there is a trailing slash at the end of the `root` option (I wonder if there is a more easier way to do this)

  Current situation:
  ```
  -r dist   --> https://base.name/index.html
  -r dist/  --> https://base.name//index.html
  ```
- Fixed path getting trimmed if root is "."
- Replaces platform-specific separator `/`/`\\` with `/` to fix the invalid `loc` urls in outputs when the program is ran on Windows (I haven't tested it).