### PR TITLE
fix: remove useless newlines in XML

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "deno.enable": true
+  "deno.enable": true,
+  "deno.config": "./deno.jsonc"
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,5 @@
-export { join, normalize, sep } from "https://deno.land/std@0.177.0/path/mod.ts";
+export {
+  join,
+  normalize,
+  sep,
+} from "https://deno.land/std@0.177.0/path/mod.ts";

--- a/gen.ts
+++ b/gen.ts
@@ -73,11 +73,12 @@ export async function generateSitemap(
  */
 export function sitemapToXML(sitemap: Sitemap) {
   return `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${
     sitemap
       .map(
-        ({ loc, lastmod }) => `
-    <url>
+        ({ loc, lastmod }) =>
+          `    <url>
         <loc>${loc}</loc>
         <lastmod>${lastmod}</lastmod>
     </url>`,

--- a/gen.ts
+++ b/gen.ts
@@ -49,7 +49,9 @@ export async function generateSitemap(
         await addDirectory(path);
       } else if (entry.isFile) {
         const { mtime } = await Deno.stat(path);
-        const relPath = distDirectory === "." ? path : path.substring(distDirectory.length);
+        const relPath = distDirectory === "."
+          ? path
+          : path.substring(distDirectory.length);
         const pathname = normalize(`/${relPath}`).split(sep).join("/");
         sitemap.push({
           loc: basename + pathname,


### PR DESCRIPTION
There were pointless newlines between each `url` entry. This PR fixes that.