### PR TITLE
feat: match/exclude glob patterns

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -1,5 +1,5 @@
-import { Command } from "https://deno.land/x/cliffy@v0.25.7/command/mod.ts";
-import { join } from "./deps.ts";
+import { Command } from "./deps/cliffy.ts";
+import { join } from "./deps/std.ts";
 import { generateSitemapXML } from "./gen.ts";
 
 await new Command()
@@ -9,8 +9,17 @@ await new Command()
   .option("-b, --basename <basename:string>", "Base URL", { required: true })
   .option("-r, --root <dir:string>", "Root working directory", { default: "." })
   .option("-o, --out <outfile:string>", "Output file, or - for standard out")
-  .action(async ({ basename, root, out }) => {
-    const xml = await generateSitemapXML(basename, root);
+  .option("-m --match <glob:string>", "Glob patterns to match", {
+    default: "**/*.html",
+  })
+  .option("-i, --ignore <glob:string>", "Glob patterns to ignore", {
+    default: "404.html",
+  })
+  .action(async ({ basename, root, out, match, ignore }) => {
+    const xml = await generateSitemapXML(basename, root, {
+      include: match,
+      exclude: ignore,
+    });
     if (out === "-") {
       console.log(xml);
     } else {

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,0 @@
-export { join, normalize, sep } from "https://deno.land/std@0.177.0/path/mod.ts";

--- a/deps/cliffy.ts
+++ b/deps/cliffy.ts
@@ -1,0 +1,1 @@
+export { Command } from "https://deno.land/x/cliffy@v0.25.7/command/mod.ts";

--- a/deps/std.ts
+++ b/deps/std.ts
@@ -1,0 +1,6 @@
+export { globToRegExp } from "https://deno.land/std@0.178.0/path/glob.ts";
+export {
+  join,
+  normalize,
+  sep,
+} from "https://deno.land/std@0.178.0/path/mod.ts";

--- a/gen.ts
+++ b/gen.ts
@@ -1,4 +1,4 @@
-import { join, normalize, sep } from "./deps.ts";
+import { globToRegExp, join, normalize, sep } from "./deps/std.ts";
 
 /**
  * An object representing an entry in a sitemap
@@ -13,6 +13,16 @@ export interface SiteMapEntry {
  * An object representing a sitemap
  */
 export type Sitemap = SiteMapEntry[];
+
+/**
+ * Options for generating a sitemap.
+ */
+export interface SiteMapOptions {
+  /** Glob pattern for files to include, overwritten by `exclude` */
+  include?: string;
+  /** Glob pattern for files to exclude, overwrites `include` */
+  exclude?: string;
+}
 
 /**
  * Generates a sitemap for a given base URL and directory, and converts it to an
@@ -39,11 +49,22 @@ export async function generateSitemapXML(
 export async function generateSitemap(
   basename: string,
   distDirectory: string,
+  options: SiteMapOptions = {},
 ) {
   const sitemap: Sitemap = [];
+  const include = options.include && globToRegExp(options.include);
+  const exclude = options.exclude && globToRegExp(options.exclude);
+  const skip: (path: string) => boolean = include
+    ? exclude
+      ? (path) => exclude.test(path) || !include.test(path)
+      : (path) => !include.test(path)
+    : exclude
+    ? (path) => exclude.test(path)
+    : () => false;
 
   async function addDirectory(directory: string) {
     for await (const entry of Deno.readDir(directory)) {
+      if (skip(entry.name)) continue;
       const path = join(directory, entry.name);
       if (entry.isDirectory) {
         await addDirectory(path);


### PR DESCRIPTION
Allows us to specify e.g. `-m **/*.html -i 404.html` to include HTML files only except the 404 page. These are also the new defaults.